### PR TITLE
Implement TopBar instrument selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test": "vitest",
     "test_run": "vitest run",
+    "test:e2e": "playwright test",
     "lint": "eslint .",
     "format": "prettier --write --plugin prettier-plugin-svelte ./",
     "format_check": "prettier --check --plugin prettier-plugin-svelte ./"
@@ -42,7 +43,8 @@
     "tailwindcss": "^4.0.9",
     "typescript": "^5.5.0",
     "vite": "^6.3.5",
-    "vitest": "^3.0.7"
+    "vitest": "^3.0.7",
+    "@playwright/test": "^1.40.1"
   },
   "type": "module",
   "dependencies": {

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  webServer: {
+    command: "npm run dev",
+    port: 5173,
+    reuseExistingServer: true,
+  },
+  testDir: "playwright",
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+})

--- a/playwright/topbar.spec.ts
+++ b/playwright/topbar.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test"
+
+// Helper to mock API
+async function setupRoutes(page) {
+  await page.route("/api/startFlow", (route) => {
+    route.fulfill({ status: 200, body: "ok" })
+  })
+  await page.route("/api/stopFlow", (route) => {
+    route.fulfill({ status: 200, body: "ok" })
+  })
+}
+
+test.describe("TopBar", () => {
+  test("start and stop streams", async ({ page }) => {
+    await setupRoutes(page)
+    await page.goto("/dashboard")
+
+    // dropdown renders
+    await page.getByText("BTC").click()
+    await expect(page.getByRole("button", { name: "ETH-PERP" })).toBeVisible()
+
+    // select instrument
+    await page.getByRole("button", { name: "ETH-PERP" }).click()
+    await expect(page.getByText("ETH")).toBeVisible()
+
+    // start streams
+    const [request] = await Promise.all([
+      page.waitForRequest((req) => req.url().includes("/api/startFlow")),
+      page.getByRole("button", { name: "Start Streams" }).click(),
+    ])
+    expect(request.method()).toBe("POST")
+    expect(await request.postDataJSON()).toEqual({ coin: "ETH-PERP" })
+
+    // button toggles
+    await expect(
+      page.getByRole("button", { name: "Stop Streams" }),
+    ).toBeVisible()
+
+    // stop streams
+    const [stopReq] = await Promise.all([
+      page.waitForRequest("/api/stopFlow"),
+      page.getByRole("button", { name: "Stop Streams" }).click(),
+    ])
+    expect(stopReq.method()).toBe("POST")
+  })
+})

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -25,3 +25,7 @@ declare global {
 }
 
 export {}
+
+declare module '$env/static/private' {
+  export const PRIVATE_STRIPE_API_KEY: string
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly PRIVATE_STRIPE_API_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/lib/components/TopBar.svelte
+++ b/src/lib/components/TopBar.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte"
+  import { writable } from "svelte/store"
+
+  const coins = ["BTC-PERP", "ETH-PERP"]
+  export const activeCoin = writable(coins[0])
+  export const streamRunning = writable(false)
+
+  const dispatch = createEventDispatcher()
+
+  async function startStreams(coin: string) {
+    await fetch("/api/startFlow", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ coin }),
+    })
+    streamRunning.set(true)
+    dispatch("start", { coin })
+  }
+
+  async function stopStreams() {
+    await fetch("/api/stopFlow", { method: "POST" })
+    streamRunning.set(false)
+    dispatch("stop")
+  }
+
+  function selectCoin(coin: string) {
+    activeCoin.update((prev) => {
+      if (prev !== coin) {
+        streamRunning.update((running) => {
+          if (running) {
+            stopStreams().then(() => startStreams(coin))
+          }
+          return running
+        })
+      }
+      return coin
+    })
+  }
+</script>
+
+<nav
+  class="navbar bg-base-300 text-base-content fixed top-0 left-0 right-0 z-50 px-4 h-12"
+>
+  <div class="flex items-center gap-2">
+    <span class="text-lg">☆</span>
+    <div class="dropdown">
+      <button type="button" class="cursor-pointer uppercase font-bold">
+        {$activeCoin.split("-")[0]}
+        <svg
+          class="inline w-3 h-3 ml-1"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M5.23 7.21L10 12l4.77-4.79-1.42-1.42L10 9.17 6.65 5.79z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </button>
+      <ul
+        class="dropdown-content menu p-2 bg-base-200 shadow rounded-box w-40"
+      >
+        {#each coins as coin}
+          <li><button type="button" on:click={() => selectCoin(coin)}>{coin}</button></li>
+        {/each}
+      </ul>
+    </div>
+  </div>
+
+  <div class="flex-1 flex justify-center gap-6 text-sm opacity-70 select-none">
+    <span>24h Vol --</span>
+    <span>OI --</span>
+    <span>Funding --</span>
+  </div>
+
+  <div class="flex-none">
+    {#if $streamRunning}
+      <button class="btn btn-error btn-sm" on:click={stopStreams}
+        >Stop Streams</button
+      >
+    {:else}
+      <button
+        class="btn btn-primary btn-sm"
+        on:click={() => startStreams($activeCoin)}>Start Streams</button
+      >
+    {/if}
+  </div>
+</nav>
+
+<style>
+  :global(body) {
+    padding-top: 3rem;
+  }
+</style>

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte"
   import PriceGauge from "$lib/components/PriceGauge.svelte"
+  import TopBar from "$lib/components/TopBar.svelte"
   import { btcFeed } from "$lib/hyperliquid/btcFeed.js"
   import { getContext } from "svelte"
   import type { Writable } from "svelte/store"
@@ -35,6 +36,8 @@
 <svelte:head>
   <title>Dashboard</title>
 </svelte:head>
+
+<TopBar />
 
 <div class="card bg-base-200 shadow-xl">
   <div class="card-body">

--- a/src/routes/api/startFlow/+server.ts
+++ b/src/routes/api/startFlow/+server.ts
@@ -1,0 +1,5 @@
+export async function POST({ request }) {
+  const data = await request.json()
+  console.log("startFlow", data)
+  return new Response("ok")
+}

--- a/src/routes/api/stopFlow/+server.ts
+++ b/src/routes/api/stopFlow/+server.ts
@@ -1,0 +1,4 @@
+export async function POST() {
+  console.log("stopFlow")
+  return new Response("ok")
+}


### PR DESCRIPTION
## Summary
- add TopBar.svelte component with coin selector and stream toggle
- wire TopBar into dashboard page
- stub startFlow/stopFlow endpoints
- include Playwright e2e test and config
- expose Stripe private key in types

## Testing
- `npm run format_check`
- `npm run lint`
- `npm run check`
- `npm run test_run`


------
https://chatgpt.com/codex/tasks/task_e_68423b7ae2248329ace935fe7d7fb064