### PR TITLE
Implement SSE stream endpoint

### DIFF
--- a/playwright/flow.spec.ts
+++ b/playwright/flow.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test"
+
+const base = "http://localhost:5173"
+
+async function readEvents(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  count: number,
+) {
+  const decoder = new TextDecoder()
+  let buffer = ""
+  const events: any[] = []
+  const start = Date.now()
+  while (events.length < count && Date.now() - start < 3000) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value)
+    let idx
+    while ((idx = buffer.indexOf("\n\n")) !== -1) {
+      const line = buffer.slice(0, idx).trim()
+      buffer = buffer.slice(idx + 2)
+      if (line.startsWith("data:")) {
+        events.push(JSON.parse(line.slice(5).trim()))
+      }
+    }
+  }
+  return events
+}
+
+test.describe("flow stream", () => {
+  test("startFlow then stopFlow closes stream", async () => {
+    let res = await fetch(`${base}/api/startFlow`, { method: "POST" })
+    expect(res.ok).toBeTruthy()
+
+    const streamRes = await fetch(`${base}/api/flowStream`)
+    expect(streamRes.status).toBe(200)
+    expect(streamRes.headers.get("content-type")).toContain("text/event-stream")
+
+    const reader = streamRes.body!.getReader()
+    const events = await readEvents(reader, 3)
+    expect(events.length).toBeGreaterThanOrEqual(3)
+
+    const stop = await fetch(`${base}/api/stopFlow`, { method: "POST" })
+    expect(stop.ok).toBeTruthy()
+
+    const result = await Promise.race([
+      reader.read(),
+      new Promise((r) => setTimeout(() => r({ timeout: true }), 1000)),
+    ])
+    expect("done" in result && (result as any).done).toBe(true)
+  })
+})
+
+test("stream responds 409 when not started", async () => {
+  const resp = await fetch(`${base}/api/flowStream`)
+  expect(resp.status).toBe(409)
+})

--- a/src/routes/api/flowStream/+server.ts
+++ b/src/routes/api/flowStream/+server.ts
@@ -1,0 +1,38 @@
+import { error } from "@sveltejs/kit"
+
+export async function GET() {
+  if (!globalThis.__flow_running)
+    throw error(409, { message: "stream not running" })
+
+  globalThis.__flow_clients = globalThis.__flow_clients || []
+  let controller: ReadableStreamDefaultController<string> | undefined
+  let response: Response
+  const stream = new ReadableStream<string>({
+    start(ctrl) {
+      controller = ctrl
+      const send = () => {
+        if (!globalThis.__flow_running) return ctrl.close()
+        ctrl.enqueue(`data: ${JSON.stringify({ price: 64000 })}\n\n`)
+      }
+      send()
+      const id = setInterval(send, 1000)
+      ctrl.signal.addEventListener("abort", () => clearInterval(id))
+    },
+    cancel() {
+      controller?.abort()
+      globalThis.__flow_clients = globalThis.__flow_clients.filter(
+        (r: Response) => r !== response,
+      )
+    },
+  })
+
+  response = new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  })
+  globalThis.__flow_clients.push(response)
+  return response
+}

--- a/src/routes/api/startFlow/+server.ts
+++ b/src/routes/api/startFlow/+server.ts
@@ -1,5 +1,6 @@
-export async function POST({ request }) {
-  const data = await request.json()
-  console.log("startFlow", data)
-  return new Response("ok")
+import { json } from "@sveltejs/kit"
+
+export const POST = async () => {
+  globalThis.__flow_running = true
+  return json({ ok: true })
 }

--- a/src/routes/api/stopFlow/+server.ts
+++ b/src/routes/api/stopFlow/+server.ts
@@ -1,4 +1,8 @@
-export async function POST() {
-  console.log("stopFlow")
-  return new Response("ok")
+import { json } from "@sveltejs/kit"
+
+export const POST = async () => {
+  globalThis.__flow_running = false
+  if (globalThis.__flow_clients)
+    globalThis.__flow_clients.forEach((res: Response) => res.body?.cancel())
+  return json({ ok: true })
 }


### PR DESCRIPTION
## Summary
- add startFlow and stopFlow endpoints for SSE streaming
- create `/api/flowStream` endpoint that returns server‑sent events
- add integration tests covering the flow stream behaviour

## Testing
- `bash checks.sh` *(fails: code style issues)*
- `npm run test:e2e` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_68423e9d8e948329a9807dfb7b6d09eb