### PR TITLE
Fix highcharts solid-gauge init

### DIFF
--- a/playwright/flow.spec.ts
+++ b/playwright/flow.spec.ts
@@ -28,7 +28,7 @@ async function readEvents(
 
 test.describe("flow stream", () => {
   test("startFlow then stopFlow closes stream", async () => {
-    let res = await fetch(`${base}/api/startFlow`, { method: "POST" })
+    const res = await fetch(`${base}/api/startFlow`, { method: "POST" })
     expect(res.ok).toBeTruthy()
 
     const streamRes = await fetch(`${base}/api/flowStream`)

--- a/src/app.css
+++ b/src/app.css
@@ -101,7 +101,6 @@
 
 /* ─── Tailwind v4 Border Compatibility Fix ───────────────────────────── */
 @layer base {
-
   *,
   ::after,
   ::before,

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -26,6 +26,6 @@ declare global {
 
 export {}
 
-declare module '$env/static/private' {
+declare module "$env/static/private" {
   export const PRIVATE_STRIPE_API_KEY: string
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,19 +1,23 @@
 <!doctype html>
 <html lang="en" data-theme="saasstartertheme-dark">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    %sveltekit.head%
+    <script>
+      // Optional: Ensure theme is set even if rehydration replaces the attribute
+      document.documentElement.setAttribute(
+        "data-theme",
+        "saasstartertheme-dark",
+      )
+    </script>
+  </head>
 
-<head>
-  <meta charset="utf-8" />
-  <link rel="icon" href="%sveltekit.assets%/favicon.png" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  %sveltekit.head%
-  <script>
-    // Optional: Ensure theme is set even if rehydration replaces the attribute
-    document.documentElement.setAttribute('data-theme', 'saasstartertheme-dark');
-  </script>
-</head>
-
-<body data-sveltekit-preload-data="hover" style="min-height: 100vh; display: flex; flex-direction: column">
-  <div style="display: contents">%sveltekit.body%</div>
-</body>
-
+  <body
+    data-sveltekit-preload-data="hover"
+    style="min-height: 100vh; display: flex; flex-direction: column"
+  >
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
 </html>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,9 +1,9 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly PRIVATE_STRIPE_API_KEY: string;
+  readonly PRIVATE_STRIPE_API_KEY: string
 }
 
 interface ImportMeta {
-  readonly env: ImportMetaEnv;
+  readonly env: ImportMetaEnv
 }

--- a/src/lib/components/TopBar.svelte
+++ b/src/lib/components/TopBar.svelte
@@ -59,11 +59,13 @@
           />
         </svg>
       </button>
-      <ul
-        class="dropdown-content menu p-2 bg-base-200 shadow rounded-box w-40"
-      >
+      <ul class="dropdown-content menu p-2 bg-base-200 shadow rounded-box w-40">
         {#each coins as coin}
-          <li><button type="button" on:click={() => selectCoin(coin)}>{coin}</button></li>
+          <li>
+            <button type="button" on:click={() => selectCoin(coin)}
+              >{coin}</button
+            >
+          </li>
         {/each}
       </ul>
     </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 
 <svelte:head>
   <script src="https://code.highcharts.com/highcharts.js" defer></script>
+  <script src="https://code.highcharts.com/highcharts-more.js" defer></script>
   <script
     src="https://code.highcharts.com/modules/solid-gauge.js"
     defer

--- a/src/routes/api/flowStream/+server.ts
+++ b/src/routes/api/flowStream/+server.ts
@@ -6,7 +6,6 @@ export async function GET() {
 
   globalThis.__flow_clients = globalThis.__flow_clients || []
   let controller: ReadableStreamDefaultController<string> | undefined
-  let response: Response
   const stream = new ReadableStream<string>({
     start(ctrl) {
       controller = ctrl
@@ -26,7 +25,7 @@ export async function GET() {
     },
   })
 
-  response = new Response(stream, {
+  const response = new Response(stream, {
     headers: {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache",


### PR DESCRIPTION
## Summary
- include `highcharts-more.js` so solid-gauge loads correctly
- adjust lint warnings in test and stream route
- run repo formatting with Prettier

## Testing
- `npm run format_check`
- `npm run lint`
- `npm run check` *(fails: "svelte-check found 13 errors" )*
- `npm run test_run`


------
https://chatgpt.com/codex/tasks/task_e_684240f274d88329946093556389ab53