### PR TITLE
Fix SSE interval cleanup

### DIFF
--- a/src/routes/api/flowStream/+server.ts
+++ b/src/routes/api/flowStream/+server.ts
@@ -5,6 +5,7 @@ export async function GET() {
     throw error(409, { message: "stream not running" })
 
   globalThis.__flow_clients = globalThis.__flow_clients || []
+  let interval: NodeJS.Timeout
   const stream = new ReadableStream<string>({
     start(ctrl) {
       const send = () => {
@@ -12,11 +13,10 @@ export async function GET() {
         ctrl.enqueue(`data: ${JSON.stringify({ price: 64000 })}\n\n`)
       }
       send()
-      const id = setInterval(send, 1000)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(ctrl as any).signal.addEventListener("abort", () => clearInterval(id))
+      interval = setInterval(send, 1000)
     },
     cancel() {
+      clearInterval(interval)
       if (globalThis.__flow_clients) {
         globalThis.__flow_clients = globalThis.__flow_clients.filter(
           (r: Response) => r !== response,


### PR DESCRIPTION
## Summary
- fix 500 error from `flowStream` SSE stub by removing non-existent controller.signal usage

## Testing
- `./checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_684247abb80c8329a3ba24ec37e2723e