### PR TITLE
Move CSP header to hooks

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -98,4 +98,13 @@ const authGuard: Handle = async ({ event, resolve }) => {
   return resolve(event)
 }
 
-export const handle: Handle = sequence(supabase, authGuard)
+const securityHeaders: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event)
+  response.headers.set(
+    "Content-Security-Policy",
+    "default-src 'self'; connect-src 'self' https://api.hyperliquid.xyz",
+  )
+  return response
+}
+
+export const handle: Handle = sequence(supabase, authGuard, securityHeaders)

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,0 @@
-export const headers = {
-  "Content-Security-Policy":
-    "default-src 'self'; connect-src 'self' https://api.hyperliquid.xyz",
-}


### PR DESCRIPTION
## Summary
- set Content-Security-Policy header in `hooks.server.ts`
- delete unused `+layout.server.ts` header file

## Testing
- `bash checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68425d6a03488329984c4dfd51295773