### PR TITLE
Fix session user trust

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,96 +1,95 @@
 // src/hooks.server.ts
 import {
-	PUBLIC_SUPABASE_ANON_KEY,
-	PUBLIC_SUPABASE_URL
-} from '$env/static/public';
-import { PRIVATE_SUPABASE_SERVICE_ROLE } from '$env/static/private';
-import { createServerClient } from '@supabase/ssr';
-import { createClient } from '@supabase/supabase-js';
-import type { Handle } from '@sveltejs/kit';
-import { sequence } from '@sveltejs/kit/hooks';
+  PUBLIC_SUPABASE_ANON_KEY,
+  PUBLIC_SUPABASE_URL,
+} from "$env/static/public"
+import { PRIVATE_SUPABASE_SERVICE_ROLE } from "$env/static/private"
+import { createServerClient } from "@supabase/ssr"
+import { createClient } from "@supabase/supabase-js"
+import type { Handle } from "@sveltejs/kit"
+import { sequence } from "@sveltejs/kit/hooks"
 
 /* ───────────────────────────── Supabase helper ───────────────────────────── */
 const supabase: Handle = async ({ event, resolve }) => {
-	event.locals.supabase = createServerClient(
-		PUBLIC_SUPABASE_URL,
-		PUBLIC_SUPABASE_ANON_KEY,
-		{
-			cookies: {
-				getAll: () => event.cookies.getAll(),
-				setAll: (arr) =>
-					arr.forEach(({ name, value, options }) =>
-						event.cookies.set(name, value, { ...options, path: '/' })
-					)
-			}
-		}
-	);
+  event.locals.supabase = createServerClient(
+    PUBLIC_SUPABASE_URL,
+    PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll: () => event.cookies.getAll(),
+        setAll: (arr) =>
+          arr.forEach(({ name, value, options }) =>
+            event.cookies.set(name, value, { ...options, path: "/" }),
+          ),
+      },
+    },
+  )
 
-	event.locals.supabaseServiceRole = createClient(
-		PUBLIC_SUPABASE_URL,
-		PRIVATE_SUPABASE_SERVICE_ROLE,
-		{ auth: { persistSession: false } }
-	);
+  event.locals.supabaseServiceRole = createClient(
+    PUBLIC_SUPABASE_URL,
+    PRIVATE_SUPABASE_SERVICE_ROLE,
+    { auth: { persistSession: false } },
+  )
 
-	// suppress deprecated warning (see GH-888)
-	// Removed direct assignment to protected property 'suppressGetSessionWarning'
+  // suppress deprecated warning (see GH-888)
+  // Removed direct assignment to protected property 'suppressGetSessionWarning'
 
-	event.locals.safeGetSession = async () => {
-		const { data: sessionData } = await event.locals.supabase.auth.getSession();
-		if (!sessionData.session) return { session: null, user: null, amr: null };
+  event.locals.safeGetSession = async () => {
+    const { data: sessionData } = await event.locals.supabase.auth.getSession()
+    if (!sessionData.session) return { session: null, user: null, amr: null }
 
-		const { data: userData, error: userErr } =
-			await event.locals.supabase.auth.getUser();
-		if (userErr) return { session: null, user: null, amr: null };
+    const { data: userData, error: userErr } =
+      await event.locals.supabase.auth.getUser()
+    if (userErr) return { session: null, user: null, amr: null }
 
-		const { data: aal, error: amrErr } =
-			await event.locals.supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-		return {
-			session: sessionData.session,
-			user: userData.user,
-			amr: amrErr ? null : aal.currentAuthenticationMethods
-		};
-	};
+    const { data: aal, error: amrErr } =
+      await event.locals.supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+    return {
+      session: sessionData.session,
+      user: userData.user,
+      amr: amrErr ? null : aal.currentAuthenticationMethods,
+    }
+  }
 
-	return resolve(event, {
-		filterSerializedResponseHeaders: (n) =>
-			n === 'content-range' || n === 'x-supabase-api-version'
-	});
-};
+  return resolve(event, {
+    filterSerializedResponseHeaders: (n) =>
+      n === "content-range" || n === "x-supabase-api-version",
+  })
+}
 
 /* ───────────────────────────── Auth guard ───────────────────────────── */
 const authGuard: Handle = async ({ event, resolve }) => {
-	const { session, user } = await event.locals.safeGetSession();
-	event.locals.session = session;
-	event.locals.user = user;
+  const { session, user } = await event.locals.safeGetSession()
+  event.locals.session = session
+  event.locals.user = user
 
-	if (event.url.pathname.startsWith('/.well-known')) {
-		return resolve(event); // skip auth for PWA probes
-	}
-	return resolve(event);
-};
+  if (event.url.pathname.startsWith("/.well-known")) {
+    return resolve(event) // skip auth for PWA probes
+  }
+  return resolve(event)
+}
 
 /* ───────────────────────────── CSP header ───────────────────────────── */
 // src/hooks.server.ts  (excerpt – keep your Supabase + auth parts)
 
 const securityHeaders: Handle = async ({ event, resolve }) => {
-	const res = await resolve(event);
+  const res = await resolve(event)
 
-	/* 1 — remove any CSP that might have been set earlier (e.g. by adapters) */
-	res.headers.delete('content-security-policy');
+  /* 1 — remove any CSP that might have been set earlier (e.g. by adapters) */
+  res.headers.delete("content-security-policy")
 
-	/* 2 — send ONE single-line CSP header */
-	res.headers.set(
-		'content-security-policy',
-		"default-src 'self'; " +
-		"connect-src 'self' https://api.hyperliquid.xyz; " +
-		"img-src 'self' data:; " +
-		"script-src 'self' 'unsafe-inline'; " +
-		"style-src  'self' 'unsafe-inline'"
-	);
+  /* 2 — send ONE single-line CSP header */
+  res.headers.set(
+    "content-security-policy",
+    "default-src 'self'; " +
+      "connect-src 'self' https://api.hyperliquid.xyz; " +
+      "img-src 'self' data:; " +
+      "script-src 'self' 'unsafe-inline'; " +
+      "style-src  'self' 'unsafe-inline'",
+  )
 
-
-	return res;
-};
+  return res
+}
 
 /* ───────────────────────────── Combined handle ───────────────────────────── */
-export const handle: Handle = sequence(supabase, authGuard, securityHeaders);
+export const handle: Handle = sequence(supabase, authGuard, securityHeaders)

--- a/src/routes/(admin)/account/api/+page.server.ts
+++ b/src/routes/(admin)/account/api/+page.server.ts
@@ -4,7 +4,7 @@ import { WebsiteBaseUrl } from "../../../../config"
 
 export const actions = {
   toggleEmailSubscription: async ({ locals: { supabase, safeGetSession } }) => {
-    const { session } = await safeGetSession()
+    const { session, user } = await safeGetSession()
 
     if (!session) {
       redirect(303, "/login")
@@ -13,7 +13,7 @@ export const actions = {
     const { data: currentProfile } = await supabase
       .from("profiles")
       .select("unsubscribed")
-      .eq("id", session.user.id)
+      .eq("id", user.id)
       .single()
 
     const newUnsubscribedStatus = !currentProfile?.unsubscribed
@@ -21,7 +21,7 @@ export const actions = {
     const { error } = await supabase
       .from("profiles")
       .update({ unsubscribed: newUnsubscribedStatus })
-      .eq("id", session.user.id)
+      .eq("id", user.id)
 
     if (error) {
       console.error("Error updating subscription status", error)
@@ -275,7 +275,7 @@ export const actions = {
     const { data: priorProfile, error: priorProfileError } = await supabase
       .from("profiles")
       .select(`*`)
-      .eq("id", session?.user.id)
+      .eq("id", user.id)
       .single()
 
     const { error } = await supabase
@@ -306,12 +306,12 @@ export const actions = {
     if (newProfile) {
       await sendAdminEmail({
         subject: "Profile Created",
-        body: `Profile created by ${session.user.email}\nFull name: ${fullName}\nCompany name: ${companyName}\nWebsite: ${website}`,
+        body: `Profile created by ${user.email}\nFull name: ${fullName}\nCompany name: ${companyName}\nWebsite: ${website}`,
       })
 
       // Send welcome email
       await sendUserEmail({
-        user: session.user,
+        user,
         subject: "Welcome!",
         from_email: "no-reply@saasstarter.work",
         template_name: "welcome_email",

--- a/src/routes/(admin)/account/api/page.server.test.ts
+++ b/src/routes/(admin)/account/api/page.server.test.ts
@@ -29,7 +29,7 @@ describe("toggleEmailSubscription", () => {
   })
 
   it("should redirect if no session", async () => {
-    mockSafeGetSession.mockResolvedValue({ session: null })
+    mockSafeGetSession.mockResolvedValue({ session: null, user: null })
 
     await expect(
       actions.toggleEmailSubscription({
@@ -45,7 +45,10 @@ describe("toggleEmailSubscription", () => {
 
   it("should toggle subscription status from false to true", async () => {
     const mockSession = { user: { id: "user123" } }
-    mockSafeGetSession.mockResolvedValue({ session: mockSession })
+    mockSafeGetSession.mockResolvedValue({
+      session: mockSession,
+      user: mockSession.user,
+    })
 
     // Mock the first query to get the current status
     mockSupabase.single.mockResolvedValueOnce({ data: { unsubscribed: false } })
@@ -72,7 +75,10 @@ describe("toggleEmailSubscription", () => {
 
   it("should toggle subscription status from true to false", async () => {
     const mockSession = { user: { id: "user123" } }
-    mockSafeGetSession.mockResolvedValue({ session: mockSession })
+    mockSafeGetSession.mockResolvedValue({
+      session: mockSession,
+      user: mockSession.user,
+    })
 
     // Mock the first query to get the current status
     mockSupabase.single.mockResolvedValueOnce({ data: { unsubscribed: true } })
@@ -99,7 +105,10 @@ describe("toggleEmailSubscription", () => {
 
   it("should return fail response if update operation fails", async () => {
     const mockSession = { user: { id: "user123" } }
-    mockSafeGetSession.mockResolvedValue({ session: mockSession })
+    mockSafeGetSession.mockResolvedValue({
+      session: mockSession,
+      user: mockSession.user,
+    })
 
     // Mock the first query to get the current status
     mockSupabase.single.mockResolvedValueOnce({ data: { unsubscribed: false } })


### PR DESCRIPTION
## Summary
- prevent reliance on session.user from getSession
- update tests for new safeGetSession data
- format with Prettier

## Testing
- `npm run format_check`
- `npm run lint`
- `npm run check`
- `npm run test_run`


------
https://chatgpt.com/codex/tasks/task_e_6842ed41ecb88329aa0282fad302f3b3