### PR TITLE
Fix CSP for Supabase fetches

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -82,7 +82,7 @@ const securityHeaders: Handle = async ({ event, resolve }) => {
   res.headers.set(
     "content-security-policy",
     "default-src 'self'; " +
-      "connect-src 'self' https://api.hyperliquid.xyz; " +
+      `connect-src 'self' https://api.hyperliquid.xyz ${PUBLIC_SUPABASE_URL}; ` +
       "img-src 'self' data:; " +
       "script-src 'self' 'unsafe-inline'; " +
       "style-src  'self' 'unsafe-inline'",


### PR DESCRIPTION
## Summary
- allow calls to the Supabase instance in the Content Security Policy

## Testing
- `bash checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842f28c2ef88329b7c2112ba1563268