### PR TITLE
Fix Supabase getSession warning

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -31,8 +31,12 @@ const supabase: Handle = async ({ event, resolve }) => {
     { auth: { persistSession: false } },
   )
 
+  if ("suppressGetSessionWarning" in event.locals.supabase.auth) {
+    // @ts-expect-error - suppressGetSessionWarning is not part of the official API
+    event.locals.supabase.auth.suppressGetSessionWarning = true
+  }
+
   // suppress deprecated warning (see GH-888)
-  // Removed direct assignment to protected property 'suppressGetSessionWarning'
 
   event.locals.safeGetSession = async () => {
     const { data: sessionData } = await event.locals.supabase.auth.getSession()

--- a/src/lib/load_helpers.ts
+++ b/src/lib/load_helpers.ts
@@ -6,6 +6,16 @@ export const load_helper = async (
   server_session: Session | null,
   supabase: SupabaseClient<Database>,
 ) => {
+  // https://github.com/supabase/auth-js/issues/888#issuecomment-2189298518
+  if ("suppressGetSessionWarning" in supabase.auth) {
+    // @ts-expect-error - suppressGetSessionWarning is not part of the official API
+    supabase.auth.suppressGetSessionWarning = true
+  } else {
+    console.warn(
+      "SupabaseAuthClient#suppressGetSessionWarning was removed. See https://github.com/supabase/auth-js/issues/888.",
+    )
+  }
+
   // on server populated on server by LayoutData, using authGuard hook
   let session = server_session
   if (isBrowser()) {
@@ -20,15 +30,6 @@ export const load_helper = async (
     }
   }
 
-  // https://github.com/supabase/auth-js/issues/888#issuecomment-2189298518
-  if ("suppressGetSessionWarning" in supabase.auth) {
-    // @ts-expect-error - suppressGetSessionWarning is not part of the official API
-    supabase.auth.suppressGetSessionWarning = true
-  } else {
-    console.warn(
-      "SupabaseAuthClient#suppressGetSessionWarning was removed. See https://github.com/supabase/auth-js/issues/888.",
-    )
-  }
   const {
     data: { user },
     error: userError,


### PR DESCRIPTION
## Summary
- silence Supabase getSession warning by setting `suppressGetSessionWarning`
- move warning suppression before `getSession` calls

## Testing
- `./checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842f49441008329915ce3d4cf39f137